### PR TITLE
Return null when the user doesn't select a folder

### DIFF
--- a/android/src/main/kotlin/io/lakscastro/sharedstorage/saf/DocumentFileApi.kt
+++ b/android/src/main/kotlin/io/lakscastro/sharedstorage/saf/DocumentFileApi.kt
@@ -342,9 +342,9 @@ internal class DocumentFileApi(private val plugin: SharedStoragePlugin) :
               )
 
             pendingResult.second.success("$uri")
-
             return true
           }
+          pendingResult.second.success(null)
         } finally {
           pendingResults.remove(OPEN_DOCUMENT_TREE_CODE)
         }


### PR DESCRIPTION
In the case the user doesn't select a folder and the uri is null, we want to still return it so the flutter consumer can respond.

Addresses #13 