### PR TITLE
solves #16

### DIFF
--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
         android:label="Shared Storage Example">
         <activity
             android:name=".MainActivity"
+            android:exported="true"
             android:configChanges="orientation|keyboardHidden|keyboard|screenSize|smallestScreenSize|locale|layoutDirection|fontScale|screenLayout|density|uiMode"
             android:hardwareAccelerated="true"
             android:launchMode="singleTop"


### PR DESCRIPTION
Solves "[Targeting S+ (version 31 and above) requires that an explicit value for android:exported be defined when intent filters are present]]" -as seen also: https://stackoverflow.com/questions/70333565/targeting-s-version-31-and-above-requires-that-an-explicit-value-for-android)
Solution is simple, add: android:exported="true" in the AndroidManifest.xml