### PR TITLE
Remove docs from `README.md`

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,116 +20,19 @@
 
 <a href="https://pub.dev/packages/shared_storage"><h4 align="center"><samp>Install It</samp></h4></a>
 
-<br>
+## Documentation
 
-## Support
+#### See the website for [documentation](https://lakscastro.gitbook.io/shared-storage)
 
-If you have ideas to share, bugs to report or need support, you can either open an issue or join our Discord server
+All documentation is also available under `/docs` to each released version which is the data source of the website
 
-<a href="https://discord.gg/86GDERXZNS">
-  <kbd><img src="https://discordapp.com/api/guilds/771498135188799500/widget.png?style=banner2" alt="Discord Banner"/></kbd>
-</a>
+You can contribute to the docs by just editing these files through the GitHub web editor!
 
-## Plugin
+Latest changes are available on `master` branch and the actual latest published package version lives under `release` branch
 
-Useful plugin to call native Android APIs from Storage Access Framework, Media Store and Environment
+`documentation` branch is an automated branch which is not edited manually
 
-Supported use-cases:
-
-```py
-# todo(@lakscastro): under-development
-```
-
-### Notes
-
-- _**Android Only**_
-- _**Alpha version**_
-- _**Supports Android 4.1+ (API Level 16+)**_
-- _**The `targetSdk` should be set to `31`**_
-
-### Features
-
-- Get top-level external/shared folders path from [`Environment` Android API](https://developer.android.com/reference/android/os/Environment)
-
-This plugin allow us to get path of top-level shared folder (Downloads, DCIM, Videos, Audio) using the following Android API's
-
-```dart
-/// Get Android [downloads] top-level shared folder
-/// You can also create a reference to a custom directory as: `EnvironmentDirectory.custom('Custom Folder')`
-final sharedDirectory =
-    await getExternalStoragePublicDirectory(EnvironmentDirectory.downloads);
-
-print(sharedDirectory.path); /// `/storage/emulated/0/Download`
-```
-
-- Get external/shared folders path from [`MediaStore` Android API](https://developer.android.com/training/data-storage/shared/media)
-
-```dart
-/// Get Android [downloads] shared folder for Android 9+
-final sharedDirectory =
-    await getMediaStoreContentDirectory(MediaStoreCollection.downloads);
-
-print(sharedDirectory.path); /// `/external/downloads`
-```
-
-- Start `OPEN_DOCUMENT_TREE` activity to prompt user to select an folder to enable write and read access to be used by the `Storage Access Framework` API
-
-```dart
-/// Get permissions to manage an Android directory
-final selectedUriDir = await openDocumentTree();
-
-print(selectedUriDir);
-```
-
-- Create a new file using the `SAF` API
-
-```dart
-/// Create a new file using the `SAF` API
-final newDocumentFile = await createDocumentFile(
-  mimeType: 'text/plain',
-  content: 'My Plain Text Comment Created by shared_storage plugin',
-  displayName: 'CreatedBySharedStorageFlutterPlugin',
-  directory: anySelectedUriByTheOpenDocumentTreeAPI,
-);
-
-print(newDocumentFile);
-```
-
-- Get all persisted [URI]s by the `openDocumentTree` API, from `SAF` API
-
-```dart
-/// You have [write] and [read] access to all persisted [URI]s
-final listOfPersistedUris = await persistedUriPermissions();
-
-print(listOfPersistedUris);
-```
-
-- Revoke a current persisted [URI], from `SAF` API
-
-```dart
-/// Can be any [URI] returned by the `persistedUriPermissions`
-final uri = ...;
-
-/// After calling this, you no longer has access to the [uri]
-await releasePersistableUriPermission(uri);
-```
-
-- Convenient method to know if a given [uri] is a persisted `uri` ("persisted uri" means that you have `write` and `read` access to the `uri` even if devices reboot)
-
-```dart
-/// Can be any [URI], but the method will only return [true] if the [uri]
-/// is also present in the list returned by `persistedUriPermissions`
-final uri = ...;
-
-/// Verify if you have [write] and [read] access to a given [uri]
-final isPersisted = await isPersistedUri(uri);
-```
-
-### Android API's
-
-Most Flutter plugins uses Android API's under the hood. So this plugin do the same, and to retrieve Android shared folder paths the following API's are being used:
-
-[`🔗android.os.Environment`](https://developer.android.com/reference/android/os/Environment#summary) [`🔗android.provider.MediaStore`](https://developer.android.com/reference/android/provider/MediaStore#summary) [`🔗android.provider.DocumentsProvider`](https://developer.android.com/guide/topics/providers/document-provider)
+All other branches are derivated from issues, new features or bug fixes
 
 ## Contributors
 


### PR DESCRIPTION
All documentation lives under the folder `/docs` and the website powered by GitBook