### PR TITLE
Fix Missing `child` member of `DocumentFile` class

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -6,6 +6,7 @@ buildscript {
     repositories {
         google()
         jcenter()
+        maven { url "https://oss.sonatype.org/content/repositories/snapshots" }
     }
 
     dependencies {
@@ -44,4 +45,9 @@ dependencies {
      * computation and queries outside the Main (UI) Thread
      */
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.4.1"
+
+    /**
+     * `SimpleStorage` library
+     */
+    implementation "com.anggrayudi:storage:1.3.0"
 }

--- a/android/src/main/kotlin/io/lakscastro/sharedstorage/storageaccessframework/DocumentFileHelperApi.kt
+++ b/android/src/main/kotlin/io/lakscastro/sharedstorage/storageaccessframework/DocumentFileHelperApi.kt
@@ -29,10 +29,10 @@ import io.lakscastro.sharedstorage.storageaccessframework.lib.*
  * natively by Android.
  *
  * This is why it is separated from the original and raw `DocumentFileApi` which is the class that
- * only exposes the APIs without modifying them
+ * only exposes the APIs without modifying them (Mirror API).
  *
  * Then here is where we can implement the main abstractions/use-cases which would be available
- * globally without modifying the strict APIs
+ * globally without modifying the strict APIs.
  */
 internal class DocumentFileHelperApi(private val plugin: SharedStoragePlugin) :
     MethodChannel.MethodCallHandler,

--- a/android/src/main/kotlin/io/lakscastro/sharedstorage/storageaccessframework/lib/DocumentCommon.kt
+++ b/android/src/main/kotlin/io/lakscastro/sharedstorage/storageaccessframework/lib/DocumentCommon.kt
@@ -8,12 +8,14 @@ import android.os.Build
 import android.provider.DocumentsContract
 import android.util.Base64
 import androidx.annotation.RequiresApi
+import androidx.annotation.RestrictTo
 import androidx.documentfile.provider.DocumentFile
 import io.lakscastro.sharedstorage.plugin.API_19
 import io.lakscastro.sharedstorage.plugin.API_21
 import io.lakscastro.sharedstorage.plugin.API_24
 import java.io.ByteArrayOutputStream
 import java.io.Closeable
+import java.io.File
 
 /**
  * Helper class to make more easy to handle callbacks using Kotlin syntax


### PR DESCRIPTION
Part of #12 

This member is implemented in `SimpleStorage` library.