### PR TITLE
Make `COLUMN_DOCUMENT_ID` optional when using with `listFiles`

### DIFF
--- a/android/src/main/kotlin/io/lakscastro/sharedstorage/storageaccessframework/lib/DocumentCommon.kt
+++ b/android/src/main/kotlin/io/lakscastro/sharedstorage/storageaccessframework/lib/DocumentCommon.kt
@@ -8,14 +8,12 @@ import android.os.Build
 import android.provider.DocumentsContract
 import android.util.Base64
 import androidx.annotation.RequiresApi
-import androidx.annotation.RestrictTo
 import androidx.documentfile.provider.DocumentFile
 import io.lakscastro.sharedstorage.plugin.API_19
 import io.lakscastro.sharedstorage.plugin.API_21
 import io.lakscastro.sharedstorage.plugin.API_24
 import java.io.ByteArrayOutputStream
 import java.io.Closeable
-import java.io.File
 
 /**
  * Helper class to make more easy to handle callbacks using Kotlin syntax
@@ -174,12 +172,17 @@ fun traverseDirectoryEntries(
   while (dirNodes.isNotEmpty()) {
     val (parent, children) = dirNodes.removeAt(0)
 
-    val requiredColumns = if (rootOnly) emptyArray() else arrayOf(
-      DocumentsContract.Document.COLUMN_MIME_TYPE,
-      DocumentsContract.Document.COLUMN_DOCUMENT_ID
-    )
+    val requiredColumns =
+      if (rootOnly) emptyArray() else arrayOf(DocumentsContract.Document.COLUMN_MIME_TYPE)
 
-    val projection = arrayOf(*columns, *requiredColumns).toSet().toTypedArray()
+    val intrinsicColumns =
+      arrayOf(DocumentsContract.Document.COLUMN_DOCUMENT_ID)
+
+    val projection = arrayOf(
+      *columns,
+      *requiredColumns,
+      *intrinsicColumns
+    ).toSet().toTypedArray()
 
     val cursor = contentResolver.query(
       children,
@@ -220,7 +223,7 @@ fun traverseDirectoryEntries(
           )
         )
 
-        if (isDirectory != null && isDirectory && !rootOnly) {
+        if (isDirectory == true && !rootOnly) {
           val nextChildren =
             DocumentsContract.buildChildDocumentsUriUsingTree(rootUri, id)
 

--- a/android/src/main/kotlin/io/lakscastro/sharedstorage/storageaccessframework/lib/DocumentCommon.kt
+++ b/android/src/main/kotlin/io/lakscastro/sharedstorage/storageaccessframework/lib/DocumentCommon.kt
@@ -201,7 +201,7 @@ fun traverseDirectoryEntries(
       while (cursor.moveToNext()) {
         val data = mutableMapOf<String, Any>()
 
-        for (column in columns) {
+        for (column in projection) {
           data[column] = cursorHandlerOf(typeOfColumn(column)!!)(
             cursor,
             cursor.getColumnIndexOrThrow(column)

--- a/docs/Usage/Storage Access Framework.md
+++ b/docs/Usage/Storage Access Framework.md
@@ -68,6 +68,8 @@ if (grantedUri != null) {
 
 This method list files lazily **over a granted uri:**
 
+> **Info** `DocumentFileColumn.id` is optional. It is required to fetch the file list from native API. So it is enabled regardless if you include this column or not. And this applies only to this API (`listFiles`).
+
 ```dart
 /// *Must* be a granted uri from `openDocumentTree`
 final Uri myGrantedUri = ...
@@ -83,7 +85,7 @@ const List<DocumentFileColumn> columns = <DocumentFileColumn>[
   DocumentFileColumn.displayName,
   DocumentFileColumn.size,
   DocumentFileColumn.lastModified,
-  DocumentFileColumn.id,
+  DocumentFileColumn.id, // Optional column, will be available/queried regardless if is or not included here
   DocumentFileColumn.mimeType,
 ];
 

--- a/example/lib/screens/folder_files/folder_file_list.dart
+++ b/example/lib/screens/folder_files/folder_file_list.dart
@@ -159,7 +159,7 @@ class _FolderFileListState extends State<FolderFileList> {
       DocumentFileColumn.displayName,
       DocumentFileColumn.size,
       DocumentFileColumn.lastModified,
-      DocumentFileColumn.id,
+      // DocumentFileColumn.id,
       DocumentFileColumn.mimeType,
     ];
 

--- a/example/lib/screens/folder_files/folder_file_list.dart
+++ b/example/lib/screens/folder_files/folder_file_list.dart
@@ -159,7 +159,8 @@ class _FolderFileListState extends State<FolderFileList> {
       DocumentFileColumn.displayName,
       DocumentFileColumn.size,
       DocumentFileColumn.lastModified,
-      // DocumentFileColumn.id,
+      // Optional column (this can't be removed because it's required to list files)
+      DocumentFileColumn.id,
       DocumentFileColumn.mimeType,
     ];
 


### PR DESCRIPTION
Fix #50.

Since this column is required to list all files, we need to query it even when not explicity requested by the plugin user.

- [x] Fix the bug at:

https://github.com/lakscastro/shared-storage/blob/1bfeb88df69938c62d7709861cc426ec71515f3c/android/src/main/kotlin/io/lakscastro/sharedstorage/storageaccessframework/lib/DocumentCommon.kt#L211-L212

- [x] Update docs to add a warning like: 'Optional column, will be queried implicity'.
- [x] Add bug reporter (@EternityForest) as contributor.
