### PR TITLE
Fix subdir list

### DIFF
--- a/android/src/main/kotlin/io/lakscastro/sharedstorage/storageaccessframework/lib/DocumentCommon.kt
+++ b/android/src/main/kotlin/io/lakscastro/sharedstorage/storageaccessframework/lib/DocumentCommon.kt
@@ -43,6 +43,8 @@ fun documentFromSingleUri(context: Context, uri: Uri): DocumentFile? {
   return DocumentFile.fromSingleUri(context, documentUri)
 }
 
+
+
 /**
  * Generate the `DocumentFile` reference from string `uri`
  */
@@ -161,10 +163,24 @@ fun traverseDirectoryEntries(
   rootOnly: Boolean,
   block: (data: Map<String, Any>, isLast: Boolean) -> Unit
 ): Boolean {
-  val childrenUri = DocumentsContract.buildChildDocumentsUriUsingTree(
-    rootUri,
-    DocumentsContract.getTreeDocumentId(rootUri)
-  )
+
+
+  var childrenUritmp: Uri?;
+
+
+  //https://stackoverflow.com/questions/41096332/issues-traversing-through-directory-hierarchy-with-android-storage-access-framew
+  //Credit to user: Foobnix
+  //If we were to always use getTreeDocumentId, it would apparently always only list the top level folder even if you request a subfolder
+
+  try {
+      //for childs and sub child dirs
+       childrenUritmp = DocumentsContract.buildChildDocumentsUriUsingTree(rootUri, DocumentsContract.getDocumentId(rootUri));
+  } catch (e:Exception) {
+      // for parent dir
+       childrenUritmp = DocumentsContract.buildChildDocumentsUriUsingTree(rootUri, DocumentsContract.getTreeDocumentId(rootUri));
+  }
+
+  val childrenUri = childrenUritmp as Uri;
 
   /// Keep track of our directory hierarchy
   val dirNodes = mutableListOf<Pair<Uri, Uri>>(Pair(rootUri, childrenUri))

--- a/docs/Usage/Storage Access Framework.md
+++ b/docs/Usage/Storage Access Framework.md
@@ -71,7 +71,7 @@ This method list files lazily **over a granted uri:**
 > **Note** `DocumentFileColumn.id` is optional. It is required to fetch the file list from native API. So it is enabled regardless if you include this column or not. And this applies only to this API (`listFiles`).
 
 ```dart
-/// *Must* be a granted uri from `openDocumentTree`
+/// *Must* be a granted uri from `openDocumentTree`, or a URI representing a child under such a granted uri.
 final Uri myGrantedUri = ...
 final DocumentFile? documentFileOfMyGrantedUri = await myGrantedUri.toDocumentFile();
 
@@ -597,6 +597,7 @@ Internal type (class). Usually they are only to keep a safe typing and are not u
 This class represents but is not the mirror of the original [`DocumentFile`](https://developer.android.com/reference/androidx/documentfile/provider/DocumentFile).
 
 This class is not intended to be instantiated, and it is only used for typing and convenient purposes.
+
 
 ### <samp>QueryMetadata</samp>
 


### PR DESCRIPTION
Closes issue #58.

Previously, calling listFiles on any document would always list the contents of the user-selected root in which the document resides.  Now it will correctly list the children of subfolders.

Please review before merging, if you do decide that this is interesting, as I have never done anything with Kotlin until today.