### PR TITLE
Close file OutputStream after file is created

### DIFF
--- a/android/src/main/kotlin/io/lakscastro/sharedstorage/storageaccessframework/DocumentFileApi.kt
+++ b/android/src/main/kotlin/io/lakscastro/sharedstorage/storageaccessframework/DocumentFileApi.kt
@@ -303,6 +303,7 @@ internal class DocumentFileApi(private val plugin: SharedStoragePlugin) :
       plugin.context.contentResolver.openOutputStream(this)?.apply {
         write(content)
         flush()
+        close()
 
         val createdFileDocument = documentFromUri(plugin.context, createdFile.uri)
 


### PR DESCRIPTION
This PR adds the missing `close()` statement as discussed in https://github.com/lakscastro/shared-storage/issues/61#issuecomment-1184727040