### PR TITLE
Update description to match `pub.dev` requirements

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: shared_storage
-description: "Flutter plugin to work with external storage with privacy-friendly APIs."
+description: "Flutter plugin to work with external storage and privacy-friendly APIs."
 version: 0.4.2
 homepage: https://github.com/lakscastro/shared-storage
 repository: https://github.com/lakscastro/shared-storage

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,5 +1,5 @@
 name: shared_storage
-description: "Flutter plugin to work with external storage."
+description: "Flutter plugin to work with external storage with privacy-friendly APIs."
 version: 0.4.2
 homepage: https://github.com/lakscastro/shared-storage
 repository: https://github.com/lakscastro/shared-storage


### PR DESCRIPTION
Update description to match `pub.dev` requirements:

As shown below, `pub.dev` requires the package constains a description with at least 60 characters:

<kbd>
  <img src="https://user-images.githubusercontent.com/51419598/179263075-bcca98d2-1897-49f8-a0a1-90eee908e367.png">
</kbd>
