### PR TITLE
Fix `DocumentFile.canRead` API call

### DIFF
--- a/lib/src/saf/document_file.dart
+++ b/lib/src/saf/document_file.dart
@@ -110,8 +110,8 @@ class DocumentFile {
   /// Alias/shortname for [openDocumentFile]
   Future<bool?> open() => openDocumentFile();
 
-  /// {@macro sharedstorage.saf.canWrite}
-  Future<bool?> canRead() async => saf.canWrite(uri);
+  /// {@macro sharedstorage.saf.canRead}
+  Future<bool?> canRead() async => saf.canRead(uri);
 
   /// {@macro sharedstorage.saf.canWrite}
   Future<bool?> canWrite() async => saf.canWrite(uri);


### PR DESCRIPTION
This PR depends of #94  since it does some changes into `DocumentFile` class.

Also, this closes #90.

**Note:** This is a breaking change since if the app is working with this buggy then switching the API will (probably) break the app.