### PR TITLE
Update docs to match latest `v0.5.0` breaking changes

### DIFF
--- a/docs/Migrate notes/Migrate to v0.3.0.md
+++ b/docs/Migrate notes/Migrate to v0.3.0.md
@@ -7,7 +7,7 @@ dependencies:
   shared_storage: v0.3.0
 ```
 
-## SDK Constraint
+## SDK constraint
 
 In `android\app\build.gradle` set `android.defaultConfig.minSdkVersion` to `19`:
 
@@ -22,7 +22,7 @@ android {
 }
 ```
 
-## Plugin Import
+## Plugin import
 
 Although this import is still supported:
 

--- a/docs/Migrate notes/Migrate to v0.5.0.md
+++ b/docs/Migrate notes/Migrate to v0.5.0.md
@@ -1,0 +1,40 @@
+There's major breaking changes when updating to `v0.5.0`, be careful.
+
+Update your `pubspec.yaml`:
+
+```yaml
+dependencies:
+  shared_storage: ^0.5.0
+```
+
+## Return type of `listFiles`
+
+Instead of:
+
+```dart
+Stream<PartialDocumentFile> fileStream = listFiles(uri);
+```
+
+use:
+
+```dart
+Stream<DocumentFile> fileStream = listFiles(uri);
+```
+
+And when reading data from each file:
+
+```dart
+// Old.
+PartialDocumentFile file = ...
+
+String displayName = file.data![DocumentFileColumn.displayName] as String;
+DateTime lastModified = DateTime.fromMillisecondsSinceEpoch(file.data![DocumentFileColumn.lastModified] as int);
+
+// New.
+DocumentFile file = ...
+
+String displayName = file.name;
+DateTime lastModified = file.lastModified;
+```
+
+It now parses all fields as class fields instead `Map<DocumentFileColumn, dynamic>` hash map.

--- a/docs/Usage/Storage Access Framework.md
+++ b/docs/Usage/Storage Access Framework.md
@@ -89,9 +89,9 @@ const List<DocumentFileColumn> columns = <DocumentFileColumn>[
   DocumentFileColumn.mimeType,
 ];
 
-final List<PartialDocumentFile> files = [];
+final List<DocumentFile> files = [];
 
-final Stream<PartialDocumentFile> onNewFileLoaded = documentFileOfMyGrantedUri.listFiles(columns);
+final Stream<DocumentFile> onNewFileLoaded = documentFileOfMyGrantedUri.listFiles(columns);
 
 onNewFileLoaded.listen((file) => files.add(file), onDone: () => print('All files were loaded'));
 ```
@@ -299,7 +299,7 @@ Returns the image thumbnail of a given `uri`, if any (e.g documents that can sho
 
 ```dart
 final Uint8List? imageBytes;
-final PartialDocumentFile file = ...
+final DocumentFile file = ...
 
 final Uri? rootUri = file.metadata?.rootUri;
 final String? documentId = file.data?[DocumentFileColumn.id] as String?;
@@ -345,7 +345,7 @@ const List<DocumentFileColumn> columns = <DocumentFileColumn>[
   DocumentFileColumn.mimeType,
 ];
 
-final Stream<PartialDocumentFile> onNewFileLoaded = documentFileOfMyGrantedUri.listFiles(columns);
+final Stream<DocumentFile> onNewFileLoaded = documentFileOfMyGrantedUri.listFiles(columns);
 ```
 
 ### <samp>delete</samp>
@@ -645,7 +645,7 @@ This class is not intended to be instantiated, and it is only used for typing an
 
 ### <samp>QueryMetadata</samp>
 
-This class wraps useful metadata of the source queries returned by the `PartialDocumentFile`.
+This class wraps useful metadata of the source queries returned by the `DocumentFile`.
 
 This class is not intended to be instantiated, and it is only used for typing and convenience purposes.
 

--- a/lib/src/saf/saf.dart
+++ b/lib/src/saf/saf.dart
@@ -129,7 +129,7 @@ Future<DocumentBitmap?> getDocumentThumbnail({
 /// ```dart
 /// /// Usage:
 ///
-/// final myState = <PartialDocumentFile>[];
+/// final myState = <DocumentFile>[];
 ///
 /// final onDocumentFile = listFiles(myUri, [DocumentFileColumn.id]);
 ///


### PR DESCRIPTION
Refer to #100.