### PR TITLE
Remove `permission_handler` dependency from `/example` project

### DIFF
--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -13,7 +13,6 @@ dependencies:
   flutter:
     sdk: flutter
   lint: ^1.8.2
-  permission_handler: ^8.1.6
   shared_storage:
     # When depending on this package from a real application you should use:
     #   shared_storage: ^x.y.z


### PR DESCRIPTION
Refer to #100.